### PR TITLE
Basic redux docs

### DIFF
--- a/source/redux.md
+++ b/source/redux.md
@@ -3,14 +3,12 @@ title: Integrating with Redux
 order: 15
 ---
 
-XXX: do we want to include James' stuff about MobX + React router?
 
-Explain how to use custom reducers for Apollo Client-related data
+By default, the Apollo Client creates its own internal Redux store to manage queries and their results. If you are already using Redux for the rest of your app, you can have the client integrate with your existing store instead. This will let you better track the different events that happen in your app, and how your client and server side data changes interleave.
 
-We should use http://docs.apollostack.com/apollo-client/redux.html
-and
+<h2 id="creating-a-store">Creating a Store</h2>
 
-If you are using a custom redux store, you can pass it into the `ApolloProvider`:
+If you want to use your own store, you'll need to pass in reducer and middleware from your Apollo Client instance; you can then pass the store into your `ApolloProvider` directly:
 
 ```js
 import { createStore, combineReducers, applyMiddleware } from 'redux';
@@ -38,6 +36,23 @@ ReactDOM.render(
 )
 ```
 
+If you'd like to use a different root key for the client reducer (rather than `apollo`), use the `reduxRootKey: "key"` option when creating the client:
+
+```js
+const client = new ApolloClient({
+  reduxRootKey: 'differentKey',
+});
+
+const store = createStore(
+  combineReducers({
+    differentKey: client.reducer(),
+  })
+);
+```
+
+<h2 id="using-connect">Using Connect</h2>
+
+
 You can continue to use `react-redux`'s `connect` higher order component to wire state into and out of your components. You can connect before or after (or both!) attaching GraphQL data to your component with `graphql`:
 
 ```js
@@ -48,11 +63,7 @@ import { connect } from 'react-redux';
 import { CLONE_LIST } from './mutations';
 import { viewList } from './actions';
 
-class List extends Component { ... }
-List.propTypes = {
-  listId: React.PropType.string.isRequired,
-  cloneList: React.PropType.function.isRequired,
-};
+const List = function({ listId, onSelectList });
 
 const withCloneList = graphql(CLONE_LIST, {
   props: ({ ownProps, mutate }) => ({
@@ -69,7 +80,7 @@ const ListWithData = withCloneList(List);
 const ListWithDataAndState = connect(
   (state) => ({ listId: state.list.id }),
   (dispatch) => ({
-    viewList(id) {
+    onSelectList(id) {
       dispatch(viewList(id));
     }
   }),

--- a/source/redux.md
+++ b/source/redux.md
@@ -4,7 +4,9 @@ order: 15
 ---
 
 
-By default, the Apollo Client creates its own internal Redux store to manage queries and their results. If you are already using Redux for the rest of your app, you can have the client integrate with your existing store instead. This will let you better track the different events that happen in your app, and how your client and server side data changes interleave.
+By default, the Apollo Client creates its own internal Redux store to manage queries and their results. If you are already using Redux for the rest of your app, you can have the client integrate with your existing store instead.
+
+This will let you better track the different events that happen in your app, and how your client and server side data changes interleave. It will also make using tools like the [Redux Dev Tools](https://github.com/zalmoxisus/redux-devtools-extension) more natural.
 
 <h2 id="creating-a-store">Creating a Store</h2>
 
@@ -25,7 +27,9 @@ const store = createStore(
     users: userReducer,
     apollo: client.reducer(),
   }),
-  applyMiddleware(client.middleware())
+  applyMiddleware(client.middleware()),
+  // If you are using the devToolsExtension, you can add it here also
+  window.devToolsExtension ? window.devToolsExtension() : f => f,
 );
 
 ReactDOM.render(


### PR DESCRIPTION
I didn't include a lot of the thunk content from http://docs.apollostack.com/apollo-client/redux.html because it doesn't seem like you'd use it w/ `react-apollo`. Perhaps we want to keep it for the "raw" Client docs? I'm not sure.