### PR TITLE
`updateQueries` documentation

### DIFF
--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -9,11 +9,11 @@ In order to incorporate the result of a query into the result of another query
 
 ## `updateQueries`
 
-Just as `fetchMore` allows you to update your UI according to the result of a query, `updateQueries` lets you update your UI based on the result of a mutation. To re-emphasize, most of the time, your UI should just update automatically based on the result of mutation as long as fields of the objects modified and the modified objects' identifiers are returned with the mutation (see the cache and `dataIdFromObject` documentation for more information).
+Just as `fetchMore` allows you to update your UI according to the result of a query, `updateQueries` lets you update your UI based on the result of a mutation. To re-emphasize: most of the time, your UI should just update automatically based on the result of a mutation as long as modified fields of objects and the object identifiers of modified objects are returned with the mutation (see the cache and `dataIdFromObject` documentation for more information).
 
-However, if you are removing or adding stuff to the list with a mutation, you'll have to use `updateQueries` to make sure that your UI reflects the change correctly.
+However, if you are removing or adding stuff to a list with a mutation or can't assign object identifiers to some of your objects, you'll have to use `updateQueries` to make sure that your UI reflects the change correctly.
 
-As our example, we'll take the comments page within the GitHunt example. When we submit a new comment, the "submit" button fires a mutation which adds a new comment to the "list" of the comments held on the server. We expose this mutation through a function prop that the `CommentsPage` component can call. This is what the code looks like:
+We'll take the comments page within GitHunt as our example. When we submit a new comment, the "submit" button fires a mutation which adds a new comment to the "list" of the comments held on the server. We expose this mutation through a function prop that the `CommentsPage` component can call. This is what the code looks like:
 
 ```javascript
 const SUBMIT_COMMENT_MUTATION = gql`
@@ -99,7 +99,7 @@ const COMMENT_QUERY = gql`
         stargazers_count
       }
     }
-  }
+  }`;
 ```
 
 Now, we have to incorporate the newly added comment returned by the mutation into the information that was already returned by the `COMMENT_QUERY` that was fired when the page was loaded. We accomplish this through `updateQueries`. Zooming in on that portion of the code:

--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -9,4 +9,121 @@ In order to incorporate the result of a query into the result of another query
 
 ## `updateQueries`
 
-In order to incorporate the result of a mutation
+Just as `fetchMore` allows you to update your UI according to the result of a query, `updateQueries` lets you update your UI based on the result of a mutation. To re-emphasize, most of the time, your UI should just update automatically based on the result of mutation as long as fields of the objects modified and the modified objects' identifiers are returned with the mutation (see the cache and `dataIdFromObject` documentation for more information).
+
+However, if you are removing or adding stuff to the list with a mutation, you'll have to use `updateQueries` to make sure that your UI reflects the change correctly.
+
+As our example, we'll take the comments page within the GitHunt example. When we submit a new comment, the "submit" button fires a mutation which adds a new comment to the "list" of the comments held on the server. We expose this mutation through a function prop that the `CommentsPage` component can call. This is what the code looks like:
+
+```javascript
+const SUBMIT_COMMENT_MUTATION = gql`
+  mutation submitComment($repoFullName: String!, $commentContent: String!) {
+    submitComment(repoFullName: $repoFullName, commentContent: $commentContent) {
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      content
+    }
+  }
+`
+const CommentsPageWithMutations = graphql(SUBMIT_COMMENT_MUTATION, {
+  props({ ownProps, mutate }) {
+    return {
+      submit({ repoFullName, commentContent }) {
+        return mutate({
+          variables: { repoFullName, commentContent },
+          optimisticResponse: {
+            __typename: 'Mutation',
+            submitComment: {
+              __typename: 'Comment',
+              postedBy: ownProps.currentUser,
+              createdAt: +new Date,
+              content: commentContent,
+            },
+          },
+          updateQueries: {
+            Comment: (prev, { mutationResult }) => {
+              const newComment = mutationResult.data.submitComment;
+              return update(prev, {
+                entry: {
+                  comments: {
+                    $unshift: [newComment],
+                  },
+                },
+              });
+            },
+          },
+        });
+      },
+    };
+  },
+})(CommentsPage);
+```
+
+If we were to look carefully at the server schema, we'd see that the mutation actually returns information about the single new comment that was added; it doesn't refetch the whole list of comments. This makes a lot of sense: if we have a thousand comments on a page, we don't want to refetch each of them if we add a single new comment.
+
+The comments page itself is rendered with the following query:
+
+```javascript
+const COMMENT_QUERY = gql`
+  query Comment($repoName: String!) {
+    # Eventually move this into a no fetch query right on the entry
+    # since we literally just need this info to determine whether to
+    # show upvote/downvote buttons
+    currentUser {
+      login
+      html_url
+    }
+    entry(repoFullName: $repoName) {
+      id
+      postedBy {
+        login
+        html_url
+      }
+      createdAt
+      comments {
+        postedBy {
+          login
+          html_url
+        }
+        createdAt
+        content
+      }
+      repository {
+        full_name
+        html_url
+        description
+        open_issues_count
+        stargazers_count
+      }
+    }
+  }
+```
+
+Now, we have to incorporate the newly added comment returned by the mutation into the information that was already returned by the `COMMENT_QUERY` that was fired when the page was loaded. We accomplish this through `updateQueries`. Zooming in on that portion of the code:
+
+```javascript
+mutate({
+  //...
+  updateQueries: {
+    Comment: (prev, { mutationResult }) => {
+      const newComment = mutationResult.data.submitComment;
+      return update(prev, {
+        entry: {
+          comments: {
+            $unshift: [newComment],
+          },
+        },
+      });
+    },
+  },
+})
+```
+
+Fundamentally, `updateQueries` is a map going from the name of a query (in our case, `Comments`) to a function that receives the previous result that this query received as well as the result returned by the mutation. In our case, the mutation returns information about the new comment. This function should then incorporate the mutation result into the result previously received by the query and return the combined result.
+
+In our `updateQueries` function for the `Comment` query, we're doing something really simple: just adding the comment we just submitted to the list of comments that the query asks for. We're doing that using the `update` function from the `react-addons-update` package, just to do it concisely. But, if you wanted to, you could write some no-helper Javascript to combine the two objects.
+
+Once the mutation fires and the result arrives from the server (or, a result is provided through optimistic UI), our `updateQueries` function for the `Comment` query will be called and the `Comment` query will be updated accordingly. These changes in the result will be mapped to React props and our UI will update as well with the new information!

--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -11,9 +11,11 @@ In order to incorporate the result of a query into the result of another query
 
 Just as `fetchMore` allows you to update your UI according to the result of a query, `updateQueries` lets you update your UI based on the result of a mutation. To re-emphasize: most of the time, your UI should just update automatically based on the result of a mutation as long as modified fields of objects and the object identifiers of modified objects are returned with the mutation (see the cache and `dataIdFromObject` documentation for more information).
 
-However, if you are removing or adding stuff to a list with a mutation or can't assign object identifiers to some of your objects, you'll have to use `updateQueries` to make sure that your UI reflects the change correctly.
+However, if you are removing or adding items to a list with a mutation or can't assign object identifiers to some of your objects, you'll have to use `updateQueries` to make sure that your UI reflects the change correctly.
 
-We'll take the comments page within GitHunt as our example. When we submit a new comment, the "submit" button fires a mutation which adds a new comment to the "list" of the comments held on the server. We expose this mutation through a function prop that the `CommentsPage` component can call. This is what the code looks like:
+We'll take the comments page within GitHunt as our example. When we submit a new comment, the "submit" button fires a mutation which adds a new comment to the "list" of the comments held on the server. As the original query that fetched the comments for the list couldn't know about this comment, Apollo can't automatically add it to the list for us. So we'll use `updateQueries` to
+
+We expose this mutation through a function prop that the `CommentsPage` component can call. This is what the code looks like:
 
 ```javascript
 const SUBMIT_COMMENT_MUTATION = gql`
@@ -122,7 +124,7 @@ mutate({
 })
 ```
 
-Fundamentally, `updateQueries` is a map going from the name of a query (in our case, `Comments`) to a function that receives the previous result that this query received as well as the result returned by the mutation. In our case, the mutation returns information about the new comment. This function should then incorporate the mutation result into the result previously received by the query and return the combined result.
+Fundamentally, `updateQueries` is a map going from the name of a query (in our case, `Comment`) to a function that receives the previous result that this query received as well as the result returned by the mutation. In our case, the mutation returns information about the new comment. This function should then incorporate the mutation result into the result previously received by the query and return the combined result.
 
 In our `updateQueries` function for the `Comment` query, we're doing something really simple: just adding the comment we just submitted to the list of comments that the query asks for. We're doing that using the `update` function from the `react-addons-update` package, just to do it concisely. But, if you wanted to, you could write some no-helper Javascript to combine the two objects.
 


### PR DESCRIPTION
Documentation for `updateQueries` (i.e. updating query results with the result of a mutation). Should eventually fix #15.